### PR TITLE
Small changes to optimize the `check_table_pair` function

### DIFF
--- a/discovery.py
+++ b/discovery.py
@@ -76,28 +76,28 @@ def check_table_pair(table_a, vectors_a, table_b, vectors_b, method='naive', tar
     target_sim = 0.0
 
     for col_a, vec_a in zip(table_a, vectors_a):
+        norm_vec_a = np.linalg.norm(vec_a)
         if col_a == target:
             if method == 'cl':
                 for col_b, vec_b in zip(table_b, vectors_b):
                     if table_a[col_a].dtype != table_b[col_b].dtype:
                         continue
-                    sim = np.dot(vec_a, vec_b) / np.linalg.norm(vec_a) / np.linalg.norm(vec_b)
+                    sim = np.dot(vec_a, vec_b) / norm_vec_a / np.linalg.norm(vec_b)
                     # if sim > 0:
                     target_sim += sim
             else:
                 continue
-        seta = set(table_a[col_a])
+        seta = set(table_a[col_a].unique())
 
         for col_b, vec_b in zip(table_b, vectors_b):
             if table_a[col_a].dtype != table_b[col_b].dtype:
                 continue
-            setb = set(table_b[col_b])
+            setb = set(table_b[col_b].unique())
             if method == 'jaccard':
                 score = len(seta.intersection(setb)) / len(seta.union(setb))
             elif method == 'cl':
                 overlap = len(seta.intersection(setb)) # / len(seta.union(setb))
-                # score = float(overlap >= 10) * np.dot(vec_a, vec_b) / np.linalg.norm(vec_a) / np.linalg.norm(vec_b)
-                score = float(overlap) * (1.0 + np.dot(vec_a, vec_b) / np.linalg.norm(vec_a) / np.linalg.norm(vec_b))
+                score = float(overlap) * (1.0 + np.dot(vec_a, vec_b) / norm_vec_a / np.linalg.norm(vec_b))
             elif method == 'overlap':
                 score = len(seta.intersection(setb)) / len(seta)
             else:


### PR DESCRIPTION
Hello! 

I have been working on using this repository as a SOTA baseline for our paper Retrieve, Merge, Predict (https://arxiv.org/abs/2402.06282), and I was having issues running the discovery step because of the set intersection step taking an extremely long time, so long it was impractical to run on our larger data lakes. 

I was able to address the issue with the very simple change in the PR, i.e. changing the way the set is built:
```
# from
        seta = set(table_a[col_a])
# to
        seta = set(table_a[col_a].unique())
```

I thought I'd share the change as it is a very small modification that allowed us to run the code in reasonable time on larger data lakes. 

I made some substantial changes to the discovery script in the main branch of my fork to ensure it was compatible with my own codebase, but I don't think they would be relevant to this repository, so they're not in this PR. 

Thanks for preparing an understandable repository! 